### PR TITLE
feat: update permit2lib address

### DIFF
--- a/src/libraries/Permit2Lib.sol
+++ b/src/libraries/Permit2Lib.sol
@@ -21,7 +21,7 @@ library Permit2Lib {
     bytes32 internal constant DAI_DOMAIN_SEPARATOR = 0xdbb8cf42e1ecb028be3f3dbc922e1d878b963f411dc388ced501601c60f7c6f7;
 
     /// @dev The address of the Permit2 contract the library will use.
-    Permit2 internal constant PERMIT2 = Permit2(address(0xCe71065D4017F316EC606Fe4422e11eB2c47c246)); // TODO
+    Permit2 internal constant PERMIT2 = Permit2(address(0x000000000022D473030F116dDEE9F6B43aC78BA3));
 
     /// @notice Transfer a given amount of tokens from one user to another.
     /// @param token The token to transfer.

--- a/test/Permit2Lib.t.sol
+++ b/test/Permit2Lib.t.sol
@@ -30,7 +30,7 @@ contract Permit2LibTest is Test, PermitSignature, GasSnapshot {
     uint256 immutable PK;
     address immutable PK_OWNER;
 
-    Permit2 immutable permit2 = new Permit2();
+    Permit2 immutable permit2 = Permit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
 
     // Use to test errors in Permit2Lib calls.
     MockPermit2Lib immutable permit2Lib = new MockPermit2Lib();
@@ -47,6 +47,8 @@ contract Permit2LibTest is Test, PermitSignature, GasSnapshot {
     constructor() {
         PK = 0xBEEF;
         PK_OWNER = vm.addr(PK);
+        Permit2 tempPermit2 = new Permit2();
+        vm.etch(address(permit2), address(tempPermit2).code);
 
         TOKEN_DOMAIN_SEPARATOR = token.DOMAIN_SEPARATOR();
         PERMIT2_DOMAIN_SEPARATOR = permit2.DOMAIN_SEPARATOR();


### PR DESCRIPTION
Permit2 was deployed on several chains at a static address -- this
commit updates the permit2lib pointer to use the right address
