### PR TITLE
Dont revert on frontrun

### DIFF
--- a/src/libraries/Permit2Lib.sol
+++ b/src/libraries/Permit2Lib.sol
@@ -143,7 +143,9 @@ library Permit2Lib {
         bytes32 r,
         bytes32 s
     ) internal {
-        (,, uint48 nonce) = PERMIT2.allowance(owner, address(token), spender);
+        (uint160 allowanceAmount,, uint48 nonce) = PERMIT2.allowance(owner, address(token), spender);
+        
+        if (uint160(amount) == allowanceAmount) return;
 
         PERMIT2.permit(
             owner,


### PR DESCRIPTION
Using `Permit2Lib.permit2` can revert in case the signature was already used in another tx (because the nonce [is included in the typehash](https://github.com/Uniswap/permit2/blob/4382d768fb549af29f71e02e2c638fb3928d3b4b/src/libraries/PermitHash.sol#L38) and because it [is increased at each signature consumption](https://github.com/Uniswap/permit2/blob/4382d768fb549af29f71e02e2c638fb3928d3b4b/src/libraries/Allowance.sol#L21))
From an application's perspective, this may not be a desirable behavior

So this PR contains a suggested change to avoid calling the Permit2 contract and update the allowance if it's unnecessary
This change has the nice side-effect of saving gas in such an unexpected edge case