### PR TITLE
refactor: name arguments in "allowance"

### DIFF
--- a/src/interfaces/IAllowanceTransfer.sol
+++ b/src/interfaces/IAllowanceTransfer.sol
@@ -106,7 +106,10 @@ interface IAllowanceTransfer {
     /// @notice A mapping from owner address to token address to spender address to PackedAllowance struct, which contains details and conditions of the approval.
     /// @notice The mapping is indexed in the above order see: allowance[ownerAddress][tokenAddress][spenderAddress]
     /// @dev The packed slot holds the allowed amount, expiration at which the allowed amount is no longer valid, and current nonce thats updated on any signature based approvals.
-    function allowance(address, address, address) external view returns (uint160, uint48, uint48);
+    function allowance(address user, address token, address spender)
+        external
+        view
+        returns (uint160 amount, uint48 expiration, uint48 nonce);
 
     /// @notice Approves the spender to use up to amount of the specified token up until the expiration
     /// @param token The token to approve


### PR DESCRIPTION
Without naming them, users cannot pass [named arguments](https://twitter.com/PaulRBerg/status/1574071928544976896).