### PR TITLE
test: remove `Permit2` import in `PermitSignature`

### DIFF
--- a/test/utils/PermitSignature.sol
+++ b/test/utils/PermitSignature.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.17;
 import {Test} from "forge-std/Test.sol";
 import {EIP712} from "openzeppelin-contracts/contracts/utils/cryptography/draft-EIP712.sol";
 import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
-import {Permit2} from "../../src/Permit2.sol";
 import {IAllowanceTransfer} from "../../src/interfaces/IAllowanceTransfer.sol";
 import {ISignatureTransfer} from "../../src/interfaces/ISignatureTransfer.sol";
 


### PR DESCRIPTION
Fixes https://github.com/Uniswap/permit2/issues/206.