### PR TITLE
feat: package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "permit2",
+  "description": "Low-overhead, next generation token approval/meta-tx system to make token approvals easier, more secure, and more consistent across applications",
+  "version": "1.0.0",
+  "bugs": "https://github.com/Uniswap/permit2/issues",
+  "keywords": [
+    "ethereum",
+    "permit2",
+    "uniswap"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Uniswap/permit2.git"
+  }
+}


### PR DESCRIPTION
Closes #228.

You want the package name to be `permit2` and not `@uniswap/permit2` so that Permit2 can be imported in the same way across dependency managers (Foundry + Hardhat).

If you name it `@uniswap/permit2`, consuming projects will need to update their import paths (which may be written as `permit2` now) to be consistent with the package name.