### PR TITLE
feat: add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "permit2",
+  "name": "@uniswap/permit2",
   "description": "Low-overhead, next generation token approval/meta-tx system to make token approvals easier, more secure, and more consistent across applications",
   "version": "1.0.0",
   "bugs": "https://github.com/Uniswap/permit2/issues",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "permit2",
+  "description": "Low-overhead, next generation token approval/meta-tx system to make token approvals easier, more secure, and more consistent across applications",
+  "version": "1.0.0",
+  "bugs": "https://github.com/Uniswap/permit2/issues",
+  "keywords": [
+    "ethereum",
+    "permit2",
+    "uniswap"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Uniswap/permit2.git"
+  }
+}


### PR DESCRIPTION
Closes #228.

You want the package name to be `@uniswap/permit2` because of this bug in Foundry:

https://github.com/foundry-rs/foundry/issues/1855#issuecomment-1625697747