### PR TITLE
downgrade interface pragmas

### DIFF
--- a/src/interfaces/IAllowanceTransfer.sol
+++ b/src/interfaces/IAllowanceTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import {IEIP712} from "./IEIP712.sol";
 

--- a/src/interfaces/IDAIPermit.sol
+++ b/src/interfaces/IDAIPermit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 interface IDAIPermit {
     /// @param holder The address of the token owner.

--- a/src/interfaces/IEIP712.sol
+++ b/src/interfaces/IEIP712.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 interface IEIP712 {
     function DOMAIN_SEPARATOR() external view returns (bytes32);

--- a/src/interfaces/IERC1271.sol
+++ b/src/interfaces/IERC1271.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 interface IERC1271 {
     /// @dev Should return whether the signature provided is valid for the provided data

--- a/src/interfaces/ISignatureTransfer.sol
+++ b/src/interfaces/ISignatureTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import {IEIP712} from "./IEIP712.sol";
 


### PR DESCRIPTION
downgrading interface pragmas to ^0.8.0 for compatibility with projects that have permit2 as a dependency