### PR TITLE
test: generalize spender

### DIFF
--- a/test/AllowanceTransferTest.t.sol
+++ b/test/AllowanceTransferTest.t.sol
@@ -98,7 +98,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testSetAllowance() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         snapStart("permitCleanWrite");
@@ -113,7 +113,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testSetAllowanceCompactSig() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getCompactPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
         assertEq(sig.length, 64);
 
@@ -129,7 +129,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testSetAllowanceIncorrectSigLength() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
         bytes memory sigExtra = bytes.concat(sig, bytes1(uint8(1)));
         assertEq(sigExtra.length, 66);
@@ -140,7 +140,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testSetAllowanceDirtyWrite() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, dirtyNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, dirtyNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKeyDirty, DOMAIN_SEPARATOR);
 
         snapStart("permitDirtyWrite");
@@ -155,7 +155,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testSetAllowanceBatchDifferentNonces() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         permit2.permit(from, permit, sig);
@@ -167,7 +167,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         IAllowanceTransfer.PermitBatch memory permitBatch =
-            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, 1);
+            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, 1, address(this));
         // first token nonce is 1, second token nonce is 0
         permitBatch.details[1].nonce = 0;
         bytes memory sig1 = getPermitBatchSignature(permitBatch, fromPrivateKey, DOMAIN_SEPARATOR);
@@ -187,7 +187,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     function testSetAllowanceBatch() public {
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         IAllowanceTransfer.PermitBatch memory permit =
-            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitBatchSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         snapStart("permitBatchCleanWrite");
@@ -209,7 +209,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
         uint160[] memory amounts = AmountBuilder.fillUInt160(2, defaultAmount);
 
         IAllowanceTransfer.PermitBatch memory permit =
-            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitBatchSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         vm.expectEmit(true, true, true, true);
@@ -231,7 +231,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     function testSetAllowanceBatchDirtyWrite() public {
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         IAllowanceTransfer.PermitBatch memory permit =
-            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, dirtyNonce);
+            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, dirtyNonce, address(this));
         bytes memory sig = getPermitBatchSignature(permit, fromPrivateKeyDirty, DOMAIN_SEPARATOR);
 
         snapStart("permitBatchDirtyWrite");
@@ -252,7 +252,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     // test setting allowance with ordered nonce and transfer
     function testSetAllowanceTransfer() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -272,7 +272,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testTransferFromWithGasSnapshot() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -294,7 +294,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testBatchTransferFromWithGasSnapshot() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -321,7 +321,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     // dirty sstore on nonce, dirty sstore on transfer
     function testSetAllowanceTransferDirtyNonceDirtyTransfer() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, dirtyNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, dirtyNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKeyDirty, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(fromDirty);
@@ -344,7 +344,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testSetAllowanceInvalidSignature() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
         snapStart("permitInvalidSigner");
         vm.expectRevert(SignatureVerification.InvalidSigner.selector);
@@ -355,7 +355,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testSetAllowanceDeadlinePassed() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 sigDeadline = block.timestamp + 100;
@@ -370,7 +370,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     function testMaxAllowance() public {
         uint160 maxAllowance = type(uint160).max;
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), maxAllowance, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), maxAllowance, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -395,7 +395,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     function testMaxAllowanceDirtyWrite() public {
         uint160 maxAllowance = type(uint160).max;
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), maxAllowance, defaultExpiration, dirtyNonce);
+            defaultERC20PermitAllowance(address(token0), maxAllowance, defaultExpiration, dirtyNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKeyDirty, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(fromDirty);
@@ -419,7 +419,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testPartialAllowance() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -442,7 +442,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testReuseOrderedNonceInvalid() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         permit2.permit(from, permit, sig);
@@ -459,7 +459,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testInvalidateNonces() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         // Invalidates the 0th nonce by setting the new nonce to 1.
@@ -476,7 +476,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testInvalidateMultipleNonces() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         // Valid permit, uses nonce 0.
@@ -484,7 +484,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
         (,, uint48 nonce1) = permit2.allowance(from, address(token0), address(this));
         assertEq(nonce1, 1);
 
-        permit = defaultERC20PermitAllowance(address(token1), defaultAmount, defaultExpiration, nonce1);
+        permit = defaultERC20PermitAllowance(address(token1), defaultAmount, defaultExpiration, nonce1, address(this));
         sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         // Invalidates the 9 nonces by setting the new nonce to 33.
@@ -510,7 +510,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testExcessiveInvalidation() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint32 numInvalidate = type(uint16).max;
@@ -526,7 +526,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testBatchTransferFrom() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -553,7 +553,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     function testBatchTransferFromMultiToken() public {
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         IAllowanceTransfer.PermitBatch memory permitBatch =
-            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitBatchSignature(permitBatch, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom0 = token0.balanceOf(from);
@@ -587,11 +587,11 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
 
     function testBatchTransferFromDifferentOwners() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         IAllowanceTransfer.PermitSingle memory permitDirty =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, dirtyNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, dirtyNonce, address(this));
         bytes memory sigDirty = getPermitSignature(permitDirty, fromPrivateKeyDirty, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -626,7 +626,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     function testLockdown() public {
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         IAllowanceTransfer.PermitBatch memory permit =
-            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitBatchSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         permit2.permit(from, permit, sig);
@@ -662,7 +662,7 @@ contract AllowanceTransferTest is Test, TokenProvider, PermitSignature, GasSnaps
     function testLockdownEvent() public {
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         IAllowanceTransfer.PermitBatch memory permit =
-            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitBatchAllowance(tokens, defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitBatchSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         permit2.permit(from, permit, sig);

--- a/test/SignatureTransfer.t.sol
+++ b/test/SignatureTransfer.t.sol
@@ -96,7 +96,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
     function testPermitTransferFrom() public {
         uint256 nonce = 0;
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom = token0.balanceOf(from);
         uint256 startBalanceTo = token0.balanceOf(address2);
@@ -112,7 +112,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
     function testPermitTransferFromCompactSig() public {
         uint256 nonce = 0;
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
-        bytes memory sig = getCompactPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getCompactPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
         assertEq(sig.length, 64);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -131,7 +131,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
     function testPermitTransferFromIncorrectSigLength() public {
         uint256 nonce = 0;
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
         bytes memory sigExtra = bytes.concat(sig, bytes1(uint8(0)));
         assertEq(sigExtra.length, 66);
 
@@ -145,7 +145,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         uint256 nonce = 0;
         // signed spender is address(this)
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom = token0.balanceOf(from);
         uint256 startBalanceTo = token0.balanceOf(address0);
@@ -161,7 +161,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
     function testPermitTransferFromInvalidNonce() public {
         uint256 nonce = 0;
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         ISignatureTransfer.SignatureTransferDetails memory transferDetails = getTransferDetails(address2, defaultAmount);
         permit2.permitTransferFrom(permit, transferDetails, from, sig);
@@ -174,7 +174,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         token0.mint(address(from), amount);
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
         permit.permitted.amount = amount;
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom = token0.balanceOf(from);
         uint256 startBalanceTo = token0.balanceOf(address2);
@@ -190,7 +190,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         token0.mint(address(from), amount);
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
         permit.permitted.amount = amount;
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom = token0.balanceOf(from);
         uint256 startBalanceTo = token0.balanceOf(address2);
@@ -207,7 +207,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         uint256 nonce = 0;
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         address[] memory to = AddressBuilder.fill(1, address(address2)).push(address(address0));
         ISignatureTransfer.SignatureTransferDetails[] memory toAmountPairs =
@@ -231,7 +231,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
 
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         // must fill address to even though token0 wont get sent.
         // transfer details must be lenght of permit
@@ -258,7 +258,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         uint256 nonce = 0;
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         ISignatureTransfer.SignatureTransferDetails[] memory toAmountPairs =
             StructBuilder.fillSigTransferDetails(2, defaultAmount, address(address2));
@@ -283,7 +283,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         // signed spender is address(this)
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom0 = token0.balanceOf(from);
         uint256 startBalanceFrom1 = token1.balanceOf(from);
@@ -307,7 +307,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
 
         address[] memory tokens = AddressBuilder.fill(10, address(token0));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom0 = token0.balanceOf(from);
         uint256 startBalanceTo0 = token0.balanceOf(address(this));
@@ -328,7 +328,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
 
         address[] memory tokens = AddressBuilder.fill(2, address(token0));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         ISignatureTransfer.SignatureTransferDetails[] memory toAmountPairs =
             StructBuilder.fillSigTransferDetails(1, defaultAmount, address(this));
@@ -340,7 +340,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
     function testGasSinglePermitTransferFrom() public {
         uint256 nonce = 0;
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom = token0.balanceOf(from);
         uint256 startBalanceTo = token0.balanceOf(address2);
@@ -359,7 +359,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         uint256 nonce = 0;
         address[] memory tokens = AddressBuilder.fill(1, address(token0));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         ISignatureTransfer.SignatureTransferDetails[] memory toAmountPairs =
             StructBuilder.fillSigTransferDetails(1, defaultAmount, address(address2));
@@ -379,7 +379,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         uint256 nonce = 0;
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         address[] memory to = AddressBuilder.fill(2, address(address2)).push(address(this));
         ISignatureTransfer.SignatureTransferDetails[] memory toAmountPairs =
@@ -410,7 +410,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
 
         bytes memory sig = getPermitBatchWitnessSignature(
-            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_BATCH_TYPEHASH, witness, DOMAIN_SEPARATOR
+            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_BATCH_TYPEHASH, witness, DOMAIN_SEPARATOR, address(this)
         );
 
         address[] memory to = AddressBuilder.fill(1, address(address2)).push(address(address0));
@@ -439,7 +439,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
         bytes memory sig = getPermitBatchWitnessSignature(
-            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_BATCH_TYPEHASH, witness, DOMAIN_SEPARATOR
+            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_BATCH_TYPEHASH, witness, DOMAIN_SEPARATOR, address(this)
         );
 
         address[] memory to = AddressBuilder.fill(1, address(address2)).push(address(address0));
@@ -456,8 +456,9 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         bytes32 witness = keccak256(abi.encode(witnessData));
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
-        bytes memory sig =
-            getPermitBatchWitnessSignature(permit, fromPrivateKey, "fake typehash", witness, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitBatchWitnessSignature(
+            permit, fromPrivateKey, "fake typehash", witness, DOMAIN_SEPARATOR, address(this)
+        );
 
         address[] memory to = AddressBuilder.fill(1, address(address2)).push(address(address0));
         ISignatureTransfer.SignatureTransferDetails[] memory toAmountPairs =
@@ -474,7 +475,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         address[] memory tokens = AddressBuilder.fill(1, address(token0)).push(address(token1));
         ISignatureTransfer.PermitBatchTransferFrom memory permit = defaultERC20PermitMultiple(tokens, nonce);
         bytes memory sig = getPermitBatchWitnessSignature(
-            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_BATCH_TYPEHASH, witness, DOMAIN_SEPARATOR
+            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_BATCH_TYPEHASH, witness, DOMAIN_SEPARATOR, address(this)
         );
 
         address[] memory to = AddressBuilder.fill(1, address(address2)).push(address(address0));
@@ -489,7 +490,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
 
     function testInvalidateUnorderedNonces() public {
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), 0);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 bitmap = permit2.nonceBitmap(from, 0);
         assertEq(bitmap, 0);
@@ -513,7 +514,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         bytes32 witness = keccak256(abi.encode(witnessData));
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitWitnessTransfer(address(token0), nonce);
         bytes memory sig = getPermitWitnessTransferSignature(
-            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_TYPEHASH, witness, DOMAIN_SEPARATOR
+            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_TYPEHASH, witness, DOMAIN_SEPARATOR, address(this)
         );
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -535,7 +536,7 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         bytes32 witness = keccak256(abi.encode(witnessData));
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitWitnessTransfer(address(token0), nonce);
         bytes memory sig = getPermitWitnessTransferSignature(
-            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_TYPEHASH, witness, DOMAIN_SEPARATOR
+            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_TYPEHASH, witness, DOMAIN_SEPARATOR, address(this)
         );
 
         ISignatureTransfer.SignatureTransferDetails memory transferDetails = getTransferDetails(address2, defaultAmount);
@@ -549,8 +550,9 @@ contract SignatureTransferTest is Test, PermitSignature, TokenProvider, GasSnaps
         MockWitness memory witnessData = MockWitness(10000000, address(5), true);
         bytes32 witness = keccak256(abi.encode(witnessData));
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitWitnessTransfer(address(token0), nonce);
-        bytes memory sig =
-            getPermitWitnessTransferSignature(permit, fromPrivateKey, "fake typehash", witness, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitWitnessTransferSignature(
+            permit, fromPrivateKey, "fake typehash", witness, DOMAIN_SEPARATOR, address(this)
+        );
 
         ISignatureTransfer.SignatureTransferDetails memory transferDetails = getTransferDetails(address2, defaultAmount);
 

--- a/test/integration/MainnetToken.t.sol
+++ b/test/integration/MainnetToken.t.sol
@@ -63,7 +63,7 @@ abstract contract MainnetTokenTest is Test, PermitSignature {
 
     function testPermit() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token()), AMOUNT, EXPIRATION, NONCE);
+            defaultERC20PermitAllowance(address(token()), AMOUNT, EXPIRATION, NONCE, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         permit2.permit(from, permit, sig);
@@ -76,7 +76,7 @@ abstract contract MainnetTokenTest is Test, PermitSignature {
 
     function testTransferFrom() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token()), AMOUNT, EXPIRATION, NONCE);
+            defaultERC20PermitAllowance(address(token()), AMOUNT, EXPIRATION, NONCE, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token().balanceOf(from);
@@ -96,7 +96,7 @@ abstract contract MainnetTokenTest is Test, PermitSignature {
 
     function testTransferFromInsufficientBalance() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token()), AMOUNT * 2, EXPIRATION, NONCE);
+            defaultERC20PermitAllowance(address(token()), AMOUNT * 2, EXPIRATION, NONCE, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         permit2.permit(from, permit, sig);
@@ -110,7 +110,7 @@ abstract contract MainnetTokenTest is Test, PermitSignature {
 
     function testBatchTransferFrom() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token()), AMOUNT, EXPIRATION, NONCE);
+            defaultERC20PermitAllowance(address(token()), AMOUNT, EXPIRATION, NONCE, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token().balanceOf(from);
@@ -136,7 +136,7 @@ abstract contract MainnetTokenTest is Test, PermitSignature {
 
     function testPermitTransferFrom() public {
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token()), NONCE);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom = token().balanceOf(from);
         uint256 startBalanceTo = token().balanceOf(RECIPIENT);
@@ -155,7 +155,7 @@ abstract contract MainnetTokenTest is Test, PermitSignature {
         bytes32 witness = keccak256(abi.encode(witnessData));
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitWitnessTransfer(address(token()), NONCE);
         bytes memory sig = getPermitWitnessTransferSignature(
-            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_TYPEHASH, witness, DOMAIN_SEPARATOR
+            permit, fromPrivateKey, FULL_EXAMPLE_WITNESS_TYPEHASH, witness, DOMAIN_SEPARATOR, address(this)
         );
 
         uint256 startBalanceFrom = token().balanceOf(from);

--- a/test/utils/DeployPermit2.t.sol
+++ b/test/utils/DeployPermit2.t.sol
@@ -44,7 +44,7 @@ contract DeployPermit2Test is Test, DeployPermit2, PermitSignature, TokenProvide
 
     function testAllowanceTransferSanityCheck() public {
         IAllowanceTransfer.PermitSingle memory permit =
-            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce);
+            defaultERC20PermitAllowance(address(token0), defaultAmount, defaultExpiration, defaultNonce, address(this));
         bytes memory sig = getPermitSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
 
         uint256 startBalanceFrom = token0.balanceOf(from);
@@ -65,7 +65,7 @@ contract DeployPermit2Test is Test, DeployPermit2, PermitSignature, TokenProvide
     function testSignatureTransferSanityCheck() public {
         uint256 nonce = 0;
         ISignatureTransfer.PermitTransferFrom memory permit = defaultERC20PermitTransfer(address(token0), nonce);
-        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR);
+        bytes memory sig = getPermitTransferSignature(permit, fromPrivateKey, DOMAIN_SEPARATOR, address(this));
 
         uint256 startBalanceFrom = token0.balanceOf(from);
         uint256 startBalanceTo = token0.balanceOf(address1);


### PR DESCRIPTION
Protocols integrating Permit2 will probably reuse the utils provided in this repo for their tests.
But the spender in their tests will most likely not be the test-contract itself.

Finding why the signature verification fails due to the hard-coded spender requires quite some knowledge of both Foundry and how certificates work, and is not that straightforward.

By generalising the spender, integrations will be sped up and better tested.
Alternatively I can also move the spender to the structs in ISignatureTransfer?